### PR TITLE
fixed .gitignore, and suppressed file not found warning from parse_in…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor/
 .env
+.vscode

--- a/lib/config.php
+++ b/lib/config.php
@@ -1,5 +1,6 @@
 <?php
-$ini = parse_ini_file(".env");
+
+$ini = @parse_ini_file(".env");
 if($ini && isset($ini["DB_URL"])){
     //load local .env file
     $db_url = parse_url($ini["DB_URL"]);


### PR DESCRIPTION
…i_file

Proof that the warning for missing .env is suppressed:
![image](https://user-images.githubusercontent.com/54863474/121061029-5b3f6a00-c791-11eb-9cd8-b8adaa6c07c1.png)
